### PR TITLE
Changes for MSVC and add i2c_start() to API

### DIFF
--- a/c/common/i2cdriver.c
+++ b/c/common/i2cdriver.c
@@ -5,8 +5,8 @@
 #include <fcntl.h>
 #if !defined(WIN32)
 #include <sys/ioctl.h>
-#endif
 #include <unistd.h>
+#endif
 #include <errno.h>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -55,7 +55,7 @@ HANDLE openSerialPort(const char *portname)
     if (portname[0] == 'C')
         fmt = "\\\\.\\%s";
     else
-        fmt == "%s";
+        fmt = "%s";
     snprintf(fullname, sizeof(fullname), fmt, portname);
     DWORD  accessdirection = GENERIC_READ | GENERIC_WRITE;
     HANDLE hSerial = CreateFile((LPCSTR)fullname,

--- a/c/common/i2cdriver.h
+++ b/c/common/i2cdriver.h
@@ -32,6 +32,7 @@ void i2c_connect(I2CDriver *sd, const char* portname);
 void i2c_getstatus(I2CDriver *sd);
 int  i2c_write(I2CDriver *sd, const uint8_t bytes[], size_t nn);
 void i2c_read(I2CDriver *sd, uint8_t bytes[], size_t nn);
+int  i2c_start(I2CDriver *sd, uint8_t dev, uint8_t op);
 void i2c_stop(I2CDriver *sd);
 
 void i2c_monitor(I2CDriver *sd, int enable);


### PR DESCRIPTION
Changes to the WIN32 part of the code for MSVC:

- `#include <unistd.h>` only when not WIN32. MSVC doesn't have it and minGW doesn't need it.
- `==` -> `=` fix

Added `int  i2c_start(I2CDriver *sd, uint8_t dev, uint8_t op);` to the public interface. This function is needed if we want to talk to I2C devices from pure C/C++ code. 
