### PR TITLE
(feature) Added i2c_disconnect to c sdk 

### DIFF
--- a/c/common/i2cdriver.c
+++ b/c/common/i2cdriver.c
@@ -184,8 +184,14 @@ void writeToSerialPort(int fd, const uint8_t *b, size_t s)
   for (i = 0; i < s; i++)
     printf("%02x ", 0xff & b[i]);
   printf("\n");
-#endif
+#endif  
 }
+
+void closeSerialPort(HANDLE hSerial)
+{
+    close((int)hSerial);
+}
+
 #endif              // }
 
 // ******************************  CCITT CRC  *********************************
@@ -266,6 +272,15 @@ void i2c_connect(I2CDriver *sd, const char* portname)
   sd->connected = 1;
   i2c_getstatus(sd);
   sd->e_ccitt_crc = sd->ccitt_crc;
+}
+
+void i2c_disconnect(I2CDriver *sd)
+{
+  if (sd->connected) {
+    closeSerialPort(sd->port);
+    sd->port = -1;
+    sd->connected = 0;
+  }
 }
 
 static void charCommand(I2CDriver *sd, char c)

--- a/c/common/i2cdriver.h
+++ b/c/common/i2cdriver.h
@@ -29,6 +29,7 @@ typedef struct {
 } I2CDriver;
 
 void i2c_connect(I2CDriver *sd, const char* portname);
+void i2c_disconnect(I2CDriver *sd);
 void i2c_getstatus(I2CDriver *sd);
 int  i2c_write(I2CDriver *sd, const uint8_t bytes[], size_t nn);
 void i2c_read(I2CDriver *sd, uint8_t bytes[], size_t nn);


### PR DESCRIPTION
This PR contains a single change. It adds a function `i2c_disconnect(I2CDriver *sd)` to the C sdk.

This function provides the opposite function of the connect() call. It closes the serial device and resets the connected flag. 

* Added closeSerialPort() for Linux build
* i2c_disconnect() closes the serial port, and resets the `connected` flag to zero.