### PR TITLE
feat(i2c): add baud rate setting functionality

### DIFF
--- a/c/common/i2cdriver.c
+++ b/c/common/i2cdriver.c
@@ -11,6 +11,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include "i2cdriver.h"
 
@@ -321,6 +322,20 @@ void i2c_getstatus(I2CDriver *sd)
     &sd->ccitt_crc
     );
     sd->mode = mode[0];
+}
+
+bool i2c_setbaud(I2CDriver *sd, unsigned int kbaud)
+{
+  if (kbaud == sd->speed) {
+    return true;
+  }
+  if ((kbaud != 100) || (kbaud != 400)) {
+    return false;
+  }
+  uint8_t ch = (kbaud == 100)?'1':'4';
+  writeToSerialPort(sd->port, &ch, 1);
+  i2c_getstatus(sd);
+  return (bool)(sd->speed == kbaud);;
 }
 
 void i2c_scan(I2CDriver *sd, uint8_t devices[128])

--- a/c/common/i2cdriver.h
+++ b/c/common/i2cdriver.h
@@ -2,6 +2,7 @@
 #define I2CDRIVER_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #if defined(WIN32)
 #include <windows.h>
@@ -35,6 +36,8 @@ int  i2c_write(I2CDriver *sd, const uint8_t bytes[], size_t nn);
 void i2c_read(I2CDriver *sd, uint8_t bytes[], size_t nn);
 int  i2c_start(I2CDriver *sd, uint8_t dev, uint8_t op);
 void i2c_stop(I2CDriver *sd);
+
+bool i2c_setbaud(I2CDriver *sd, int kbaud);
 
 void i2c_monitor(I2CDriver *sd, int enable);
 void i2c_capture(I2CDriver *sd);


### PR DESCRIPTION
Add a new function `i2c_setbaud` allowing the baud rate of the I2C connection to be set. This feature provides the ability to configure the communication speed to standard values (100kbps or 400kbps). To support this, `stdbool.h` is included for returning boolean status from the new function. The implementation checks if the requested baud rate matches the current one, and updates it if necessary through a serialized command, with feedback obtained immediately by calling `i2c_getstatus`. This commit includes both the prototype in `i2cdriver.h` and the definition in `i2cdriver.c`.