### PR TITLE
refactor(i2cgui): use daemon parameter in Thread initialization

### DIFF
--- a/python/samples/i2cgui.py
+++ b/python/samples/i2cgui.py
@@ -263,8 +263,7 @@ class Frame(wx.Frame):
         if d1 is not None:
             cb.SetValue(d1)
 
-        t = threading.Thread(target=ping_thr, args=(self, ))
-        t.setDaemon(True)
+        t = threading.Thread(target=ping_thr, args=(self, ), daemon=True)
         t.start()
 
     def start(self, rw):


### PR DESCRIPTION
Simplified the creation of the threading.Thread by utilizing the 'daemon' keyword argument directly during instantiation. This enhances code readability and aligns with modern Python practices. The functionality remains unchanged, as the thread is still set to run as a daemon.